### PR TITLE
Upgrade to Jupyterlab 3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,17 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        'selector': 'interface',
+        'format': ['PascalCase'],
+        'custom': {
+          'regex': '^I[A-Z]',
+          'match': true
+        }
+      }
+    ],
     '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
     branches: '*'
 
@@ -11,23 +11,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '10.x'
+       node-version: '12.x'
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.7'
         architecture: 'x64'
+    
+    
+    - name: Setup pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: pip-3.7-${{ hashFiles('package.json') }}
+        restore-keys: |
+          pip-3.7-
+          pip-
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Setup yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          yarn-
+    
     - name: Install dependencies
-      run: python -m pip install jupyterlab
+      run: python -m pip install -U jupyterlab~=3.0 jupyter_packaging~=0.7.9
     - name: Build the extension
       run: |
         jlpm
         jlpm run eslint:check
+        python -m pip install .
 
-        jupyter labextension install .
-
+        jupyter labextension list 2>&1 | grep -ie "@data-exp-lab/jupyterlab-twitch.*OK"
         python -m jupyterlab.browser_check

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,109 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 *.tsbuildinfo
+jupyterlab_twitch/labextension
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 **/node_modules
 **/lib
 **/package.json
+jupyterlab_twitch

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,24 @@
+include LICENSE
+include README.md
+include pyproject.toml
+include jupyter-config/jupyterlab_twitch.json
+
+include package.json
+include install.json
+include ts*.json
+include yarn.lock
+
+graft jupyterlab_twitch/labextension
+
+# Javascript files
+graft src
+graft style
+prune **/node_modules
+prune lib
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/install.json
+++ b/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "jupyterlab_twitch",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_twitch"
+}

--- a/jupyterlab_twitch/__init__.py
+++ b/jupyterlab_twitch/__init__.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from ._version import __version__
 
+from .twitch_player import TwitchPlayerModel
+
 HERE = Path(__file__).parent.resolve()
 
 with (HERE / "labextension" / "package.json").open() as fid:

--- a/jupyterlab_twitch/__init__.py
+++ b/jupyterlab_twitch/__init__.py
@@ -1,3 +1,17 @@
-from ._version import version_info, __version__
 
-from .twitch_player import *
+import json
+from pathlib import Path
+
+from ._version import __version__
+
+HERE = Path(__file__).parent.resolve()
+
+with (HERE / "labextension" / "package.json").open() as fid:
+    data = json.load(fid)
+
+def _jupyter_labextension_paths():
+    return [{
+        "src": "labextension",
+        "dest": data["name"]
+    }]
+

--- a/jupyterlab_twitch/_version.py
+++ b/jupyterlab_twitch/_version.py
@@ -1,9 +1,19 @@
-version_info = (0, 1, 1, 'dev', 0)
+import json
+from pathlib import Path
 
-_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': '',
-        'dev': 'dev'}
+__all__ = ["__version__"]
 
-__version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
-  '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
+def _fetchVersion():
+    HERE = Path(__file__).parent.resolve()
 
-EXTENSION_VERSION='~0.1.1'
+    for settings in HERE.rglob("package.json"): 
+        try:
+            with settings.open() as f:
+                return json.load(f)["version"]
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
+__version__ = _fetchVersion()
+

--- a/jupyterlab_twitch/twitch_player.py
+++ b/jupyterlab_twitch/twitch_player.py
@@ -2,7 +2,8 @@ import ipywidgets as ipywidgets
 import traitlets
 from ipywidgets import widget_serialization
 
-from ._version import EXTENSION_VERSION
+from ._version import __version__
+EXTENSION_VERSION = "~" + __version__
 
 @ipywidgets.register
 class TwitchPlayerModel(ipywidgets.DOMWidget):

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "Matthew Turk",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "style/index.js"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -25,39 +26,51 @@
     "url": "https://github.com/data-exp-lab/jupyterlab_twitch.git"
   },
   "scripts": {
-    "build": "tsc",
-    "build:lib": "tsc",
+    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
     "build:all": "jlpm run build:lib",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:lib": "tsc",
+    "build:prod": "jlpm run build:lib && jlpm run build:labextension",
     "clean": "jlpm run clean:lib",
+    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
+    "clean:labextension": "rimraf jupyterlab_twitch/labextension",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:all": "jlpm run clean:lib",
     "eslint": "eslint . --ext .ts,.tsx --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",
-    "prepare": "jlpm run clean && jlpm run build",
-    "watch": "tsc -w"
+    "install:extension": "jupyter labextension develop --overwrite .",
+    "prepare": "jlpm run clean && jlpm run build:prod",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:labextension": "jupyter labextension watch .",
+    "watch:src": "tsc -w"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^3.0.0",
-    "@jupyterlab/application": "^2.0.0",
-    "@jupyterlab/apputils": "^2.1.1",
-    "@lumino/coreutils": "^1.5.0",
-    "@lumino/widgets": "^1.13.0",
+    "@jupyterlab/application": "^3.0.4",
+    "@jupyterlab/apputils": "^3.0.3",
+    "@lumino/coreutils": "^1.5.3",
+    "@lumino/widgets": "^1.16.1",
     "@types/node": "^14.0.13"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^3.7.0",
-    "eslint": "^7.5.0",
-    "eslint-config-prettier": "^7.0.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "2.2.1",
+    "@jupyterlab/builder": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
+    "eslint": "^7.14.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "typescript": "~4.1.2"
+    "typescript": "~4.1.3"
   },
   "sideEffects": [
-    "style/*.css"
+    "style/*.css",
+    "style/index.js"
   ],
   "jupyterlab": {
-    "extension": "lib/plugin"
-  }
+    "extension": "lib/plugin",
+    "outputDir": "jupyterlab_twitch/labextension"
+  },
+  "styleModule": "style/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "watch:src": "tsc -w"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^3.0.0",
+    "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4",
     "@jupyterlab/application": "^3.0.4",
-    "@jupyterlab/apputils": "^3.0.3",
-    "@lumino/coreutils": "^1.5.3",
-    "@lumino/widgets": "^1.16.1",
+    "@jupyterlab/coreutils": "^5.0.2",
+    "@jupyterlab/mainmenu": "^3.0.3",
+    "@jupyterlab/services": "^6.0.3",
+    "@jupyterlab/apputils": "^3.0.0",
     "@types/node": "^14.0.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-exp-lab/jupyterlab-twitch",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A JupyterLab extension.",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.4.0", "jupyterlab~=2.0", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,83 +1,89 @@
 """
-Setup Module to setup Python Handlers for the jupyterlab_twitch extension.
+jupyterlab_twitch setup
 """
-import os
+import json
+from pathlib import Path
 
 from jupyter_packaging import (
-    create_cmdclass, install_npm, ensure_targets,
-    combine_commands, ensure_python, get_version,
+    create_cmdclass,
+    install_npm,
+    ensure_targets,
+    combine_commands,
+    skip_if_exists
 )
 import setuptools
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = Path(__file__).parent.resolve()
 
 # The name of the project
-name="jupyterlab_twitch"
+name = "jupyterlab_twitch"
 
-# Ensure a valid python version
-ensure_python(">=3.7")
-
-# Get our version
-version = get_version(os.path.join(name, "_version.py"))
-
-lab_path = os.path.join(HERE, name, "labextension")
+lab_path = (HERE / name / "labextension")
 
 # Representative files that should exist after a successful build
 jstargets = [
-    os.path.join(HERE, "lib", "index.js"),
-    os.path.join(HERE, "lib", "widget.js"),
+    str(lab_path / "package.json"),
 ]
 
 package_data_spec = {
-    name: [
-        "*"
-    ]
+    name: ["*"],
 }
 
+labext_name = "@data-exp-lab/jupyterlab-twitch"
+
 data_files_spec = [
+    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
+    ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
 ]
 
-cmdclass = create_cmdclass("jsdeps", 
+cmdclass = create_cmdclass("jsdeps",
     package_data_spec=package_data_spec,
     data_files_spec=data_files_spec
 )
 
-cmdclass["jsdeps"] = combine_commands(
-    install_npm(HERE, build_cmd="build:all", npm=["jlpm"]),
+js_command = combine_commands(
+    install_npm(HERE, build_cmd="build:prod", npm=["jlpm"]),
     ensure_targets(jstargets),
 )
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+is_repo = (HERE / ".git").exists()
+if is_repo:
+    cmdclass["jsdeps"] = js_command
+else:
+    cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
+
+long_description = (HERE / "README.md").read_text()
+
+# Get the package info from package.json
+pkg_json = json.loads((HERE / "package.json").read_bytes())
 
 setup_args = dict(
     name=name,
-    version=version,
-    url="https://github.com/data-exp-lab/jupyterlab_twitch",
-    author="Data Exploration Lab",
-    author_email="matthewturk@gmail.com",
-    description= 'A widget for Twitch in Jupyterlab', 
-    long_description= long_description,
+    version=pkg_json["version"],
+    url=pkg_json["homepage"],
+    author=pkg_json["author"],
+    description=pkg_json["description"],
+    license=pkg_json["license"],
+    long_description=long_description,
     long_description_content_type="text/markdown",
-    cmdclass= cmdclass,
+    cmdclass=cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab~=2.0",
-        "ipywidgets>=7.5.1",
-        "traitlets>=4.3.3",
+        "jupyterlab~=3.0",
     ],
     zip_safe=False,
     include_package_data=True,
-    license="BSD-3-Clause",
+    python_requires=">=3.6",
     platforms="Linux, Mac OS X, Windows",
-    keywords=["Jupyter", "JupyterLab"],
+    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
     classifiers=[
         "License :: OSI Approved :: BSD License",
-        "Development Status :: 4 - Beta",
-        "Framework :: IPython",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: Jupyter",
     ],
 )

--- a/src/player.ts
+++ b/src/player.ts
@@ -23,7 +23,7 @@ export class TwitchPlayerWidget extends Widget {
         channel: this.channel,
         height: '100%',
         width: '100%',
-        layout: 'video-with-chat',
+        layout: 'video-with-chat'
       };
 
       this.embed = new Twitch.Embed('twitch-embed', params);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,9 @@
-import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
-
 import {
-  JupyterFrontEnd,
   JupyterFrontEndPlugin,
-  ILayoutRestorer,
+  JupyterFrontEnd
 } from '@jupyterlab/application';
+
+import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
 import {
   ICommandPalette,
@@ -20,7 +19,7 @@ const EXTENSION_ID = MODULE_NAME + ':plugin';
 
 const extension: JupyterFrontEndPlugin<void> = {
   id: EXTENSION_ID,
-  requires: [ICommandPalette, ILayoutRestorer, IJupyterWidgetRegistry],
+  requires: [ICommandPalette, IJupyterWidgetRegistry],
   autoStart: true,
   activate: async (
     app: JupyterFrontEnd,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,7 +8,7 @@ import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 import {
   ICommandPalette,
   MainAreaWidget,
-  InputDialog,
+  InputDialog
 } from '@jupyterlab/apputils';
 
 import * as widgetExports from './widget';
@@ -30,7 +30,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     registry.registerWidget({
       name: MODULE_NAME,
       version: MODULE_VERSION,
-      exports: widgetExports,
+      exports: widgetExports
     });
 
     const command = 'twitch:open';
@@ -42,7 +42,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         if (!widget) {
           const result = await InputDialog.getText({
             title: 'Channel',
-            text: 'mst3k',
+            text: 'mst3k'
           });
           if (!result.button.accept) {
             return;
@@ -59,11 +59,11 @@ const extension: JupyterFrontEndPlugin<void> = {
         widget.content.update();
 
         app.shell.activateById(widget.id);
-      },
+      }
     });
 
     palette.addItem({ command, category: 'Twitch' });
-  },
+  }
 };
 
 export default extension;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -21,7 +21,7 @@ export class TwitchPlayerModel extends DOMWidgetModel {
       width: 500,
       height: 500,
       volume: 0.2,
-      muted: false,
+      muted: false
     };
   }
 
@@ -50,7 +50,7 @@ export class TwitchPlayerView extends DOMWidgetView {
       channel: this.model.get('channel'),
       height: this.model.get('height'),
       width: this.model.get('width'),
-      layout: 'video',
+      layout: 'video'
     };
     this.displayed.then(() => {
       this.embed = new Twitch.Embed(this.divId, params);

--- a/style/base.css
+++ b/style/base.css
@@ -1,0 +1,12 @@
+.twitch-widget {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: auto;
+}
+
+div#twitch-embed {
+    display: flex;
+    height: 100%;
+    width: 100%;
+}

--- a/style/index.css
+++ b/style/index.css
@@ -1,12 +1,1 @@
-.twitch-widget {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    overflow: auto;
-}
-
-div#twitch-embed {
-    display: flex;
-    height: 100%;
-    width: 100%;
-}
+@import url('base.css');

--- a/style/index.js
+++ b/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "strict": true,
     "strictNullChecks": false,
     "target": "es2017",
-    "types": []
+    "skipLibCheck": true,
+    "types": ["node"],
+    "allowJs": true
   },
   "include": ["src/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
     "strict": true,
     "strictNullChecks": false,
     "target": "es2017",
-    "allowJs": true,
-    "skipLibCheck": true
+    "types": []
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
This updates the plugin to work with Jupyterlab 3.  I am not sure it will still work with Jupyterlab 2, but my reading of the upgrade path is that it should.

This should also bundle the javascript and thus make it easier to distribute.  Everything will be in the pip package!